### PR TITLE
16 add link for enrollment after authentication

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
     <namespace>PrivacyIDEA</namespace>
     <category>security</category>
     <dependencies>
-        <nextcloud min-version="29" max-version="30"/>
+        <nextcloud min-version="29" max-version="31"/>
     </dependencies>
     <two-factor-providers>
         <provider>OCA\PrivacyIDEA\Provider\PrivacyIDEAProvider</provider>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"require": {
 		"bamarni/composer-bin-plugin": "^1.8",
-		"php": "^8.1",
+		"php": "^8.3",
       "ext-curl": "*"
     },
 	"require-dev": {
@@ -40,7 +40,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.3"
 		}
 	}
 }

--- a/lib/PIClient/PIChallenge.php
+++ b/lib/PIClient/PIChallenge.php
@@ -25,6 +25,9 @@ class PIChallenge
 	/* @var string Image data extracted from this challenge. */
 	public string $image = '';
 
+    /* @var string Enrollment link if available. */
+    public string $enrollmentLink = '';
+
 	/* @var string TransactionId to reference this challenge in later requests. */
 	public string $transactionID = '';
 

--- a/lib/PIClient/PIResponse.php
+++ b/lib/PIClient/PIResponse.php
@@ -130,6 +130,9 @@ class PIResponse
 				if (isset($challenge['image'])) {
 					$tmp->image = $challenge['image'];
 				}
+                if (isset($challenge['link'])) {
+                    $tmp->enrollmentLink = $challenge['link'];
+                }
 				if (isset($challenge['attributes'])) {
 					$tmp->attributes = $challenge['attributes'];
 				}

--- a/lib/Provider/PrivacyIDEAProvider.php
+++ b/lib/Provider/PrivacyIDEAProvider.php
@@ -150,11 +150,14 @@ class PrivacyIDEAProvider implements IProvider
 		}
 		if ($this->session->get('piImgPush') !== null) {
 			$template->assign('imgPush', $this->session->get('piImgPush'));
-		}
-		if ($this->session->get('piImgOTP') !== null) {
-			$template->assign('imgOTP', $this->session->get('piImgOTP'));
-		}
-		$template->assign('activateAutoSubmitOtpLength', $this->getAppValue('piActivateAutoSubmitOtpLength', '0'));
+        }
+        if ($this->session->get('piImgOTP') !== null) {
+            $template->assign('imgOTP', $this->session->get('piImgOTP'));
+        }
+        if ($this->session->get('piEnrollmentLink') !== null) {
+            $template->assign('enrollmentLink', $this->session->get('piEnrollmentLink'));
+        }
+        $template->assign('activateAutoSubmitOtpLength', $this->getAppValue('piActivateAutoSubmitOtpLength', '0'));
 		$template->assign('autoSubmitOtpLength', $this->getAppValue('piAutoSubmitOtpLength', '6'));
 		$template->assign('pollInBrowser', $this->getAppValue('piPollInBrowser', '0'));
 		$template->assign('pollInBrowserUrl', $this->getAppValue('piPollInBrowserURL', ''));
@@ -343,7 +346,7 @@ class PrivacyIDEAProvider implements IProvider
 				$this->session->set('piWebAuthnSignRequest', $response->getWebauthnSignRequest());
 			}
 
-			// Search for the images
+			// Search for the images & enrollment link
 			foreach ($response->getMultiChallenge() as $challenge) {
 				if (!empty($challenge->image)) {
 					if (!empty($challenge->clientMode) && $challenge->clientMode === 'interactive') {
@@ -354,6 +357,9 @@ class PrivacyIDEAProvider implements IProvider
 						$this->session->set('piImageWebAuthn', $challenge->image);
 					}
 				}
+                if (!empty($challenge->enrollmentLink)) {
+                    $this->session->set('piEnrollmentLink', $challenge->enrollmentLink);
+                }
 			}
 		} elseif (!empty($response->getErrorCode())) {
 			// privacyIDEA returned an error, prepare it to display.

--- a/templates/main.php
+++ b/templates/main.php
@@ -18,7 +18,7 @@ Util::addStyle('privacyidea', 'main');
     <br>
 <?php endif; ?>
 
-<!-- IMAGES -->
+<!-- IMAGES & ENROLLMENT LINK -->
 <?php if (!empty($_['imgWebauthn']) && $_['mode'] === 'webauthn') : ?>
     <img class="tokenImages" src="<?php p($_['imgWebauthn']); ?>" alt="WebAuthn image"><br><br>
 <?php endif;
@@ -28,23 +28,23 @@ if (!empty($_['imgPush']) && $_['mode'] === 'push') : ?>
 if (!empty($_['imgOTP']) && $_['mode'] === 'otp') : ?>
     <img class="tokenImages" id="imgOtp" src="<?php p($_['imgOTP']); ?>" alt="OTP image"><br><br>
 <?php endif;?>
+<?php if (!empty($_['enrollmentLink'])) : ?>
+    <a id="enrollmentLink" href="<?php p($_['enrollmentLink']); ?>">Enrollment Link</a>
+<?php endif;?>
 
 <!-- FORM -->
 <form method="POST" id="piLoginForm" name="piLoginForm">
     <?php if (!isset($_['hideOTPField']) || !$_['hideOTPField']) : ?>
     <?php if (isset($_['separateOTP']) && $_['separateOTP']) : ?>
         <label>
-            <input id="passField" type="password" name="passField" placeholder="Password" autocomplete="off" required
-                   autofocus>
+            <input id="passField" type="password" name="passField" placeholder="Password" autocomplete="off" required autofocus>
         </label>
         <?php endif; ?>
         <label>
-            <input id="otp" type="password" name="challenge" placeholder="OTP" autocomplete="off" required
-                   autofocus>
+            <input id="otp" type="password" name="challenge" placeholder="OTP" autocomplete="off" required autofocus>
         </label>
         <br>
-        <input id="submitButton" type="submit" class="button"
-               value="<?php if (isset($_['verify'])) : p($_['verify']); endif; ?>">
+        <input id="submitButton" type="submit" class="button" value="<?php if (isset($_['verify'])) : p($_['verify']); endif; ?>">
     <?php endif; ?>
 
     <!-- Hidden input that saves the changes -->

--- a/templates/main.php
+++ b/templates/main.php
@@ -29,7 +29,7 @@ if (!empty($_['imgOTP']) && $_['mode'] === 'otp') : ?>
     <img class="tokenImages" id="imgOtp" src="<?php p($_['imgOTP']); ?>" alt="OTP image"><br><br>
 <?php endif;?>
 <?php if (!empty($_['enrollmentLink'])) : ?>
-    <a id="enrollmentLink" href="<?php p($_['enrollmentLink']); ?>">Enrollment Link</a>
+    <a id="enrollmentLink" href="<?php p($_['enrollmentLink']); ?>" target="_blank" rel="noopener noreferrer">Enrollment Link</a>
 <?php endif;?>
 
 <!-- FORM -->


### PR DESCRIPTION
This pull request introduces several updates to enhance compatibility, add a new feature for enrollment links, and improve code functionality. The most notable changes include updating dependencies for Nextcloud and PHP versions, adding support for enrollment links in the PrivacyIDEA challenge and response handling, and updating templates to display the enrollment link.

### Compatibility Updates

* [`appinfo/info.xml`](diffhunk://#diff-ab97a56738913a50d2334c4d3f10991748d3e29d011f5a674734b63d33d5ce9eL22-R22): Updated the Nextcloud dependency to support versions up to 31.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L29-R29): Updated the required PHP version from `^8.1` to `^8.3` for both `require` and `platform` sections. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L29-R29) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L43-R43)

### Enrollment Link Feature

* [`lib/PIClient/PIChallenge.php`](diffhunk://#diff-c75117cad303e9402f60059a34f883ece10f3b85605f57745640737b0cc6a002R28-R30): Added a new property `enrollmentLink` to store the enrollment link if available.
* [`lib/PIClient/PIResponse.php`](diffhunk://#diff-7bcc162180641318ea081f148325ab6372f27069c2a1c049a4792a95d79d1870R133-R135): Updated the `fromJSON` method to parse and set the `enrollmentLink` property from the JSON response.
* `lib/Provider/PrivacyIDEAProvider.php`: 
  - Updated the `getTemplate` method to assign the enrollment link to the template if available.
  - Enhanced the `processPIResponse` method to handle and store the enrollment link in the session. [[1]](diffhunk://#diff-ca2faf6ddc1d650e3627fcb17276c32dac20aa7bf925808f9f0b8fc68e7dffeeL346-R349) [[2]](diffhunk://#diff-ca2faf6ddc1d650e3627fcb17276c32dac20aa7bf925808f9f0b8fc68e7dffeeR360-R362)
* [`templates/main.php`](diffhunk://#diff-20d8d1fad5f963133de13573cad9a4133364ef03857c61a6c3500101c808b048L21-R21): Added logic to display the enrollment link in the user interface if it is available. [[1]](diffhunk://#diff-20d8d1fad5f963133de13573cad9a4133364ef03857c61a6c3500101c808b048L21-R21) [[2]](diffhunk://#diff-20d8d1fad5f963133de13573cad9a4133364ef03857c61a6c3500101c808b048R31-R47)